### PR TITLE
Obrazci lepše formatirani

### DIFF
--- a/nadlogar/config/settings.py
+++ b/nadlogar/config/settings.py
@@ -40,6 +40,8 @@ INSTALLED_APPS = [
     "students",
     "quizzes",
     "problems",
+    # third party apps
+    "crispy_forms",
 ]
 
 MIDDLEWARE = [
@@ -125,3 +127,5 @@ USE_TZ = True
 STATIC_URL = "/static/"
 
 STATICFILES_DIRS = [os.path.join(BASE_DIR, "static")]
+
+CRISPY_TEMPLATE_PACK = 'bootstrap4'

--- a/nadlogar/requirements.txt
+++ b/nadlogar/requirements.txt
@@ -1,1 +1,2 @@
 django==3.0.7
+django-crispy-forms==1.11.1

--- a/nadlogar/static/formstyle.css
+++ b/nadlogar/static/formstyle.css
@@ -1,0 +1,11 @@
+
+input, optgroup, select, textarea {
+    width: -webkit-fill-available;
+    font-size: 1rem;
+    height: 2em;
+}
+
+#btn-cancel{
+    float: right;
+    background: #777777;
+}

--- a/nadlogar/templates/bulma.html
+++ b/nadlogar/templates/bulma.html
@@ -7,10 +7,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% block title %}Nadlogar{% endblock title %}</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.1/css/bulma.min.css">
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
+    {% block css_import %} {% endblock css_import%}
+</head>
     <script defer src="https://use.fontawesome.com/releases/v5.14.0/js/all.js"></script>
     <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
-    <script src="{% static "nadlogar.js" %}"></script>
+    <script src="{% static 'nadlogar.js' %}"></script>
 </head>
 
 <body>

--- a/nadlogar/templates/form.html
+++ b/nadlogar/templates/form.html
@@ -1,5 +1,14 @@
 {% extends 'bulma.html' %}
 
+{% load crispy_forms_tags %}
+{% crispy form form.helper %}
+
+{% block css_import %}
+{% load static %}
+<link rel="stylesheet" type="text/css" href="{% static 'formstyle.css' %}">
+{% endblock css_import %}
+
+
 {% block body %}
 <div class="modal is-active">
     <form method="{% block method %}GET{% endblock method %}">
@@ -15,13 +24,14 @@
             </header>
             <section class="modal-card-body">
                 {% block form_body %}
-                {{ form.as_ul }}
+                {{ form|crispy }}
                 {% endblock form_body %}
                 {% csrf_token %}
             </section>
             <footer class="modal-card-foot">
                 {% block actions %}
-                <button class="button is-fullwidth is-primary">{% block submit %}Cancel{% endblock submit %}</button>
+                <button id="btn-cancel" type="reset" class="button is-fullwidth is-primary" onclick="javascript:history.back();">Nazaj</button>
+                <button class="button is-fullwidth is-primary">{% block submit %}Potrdi{% endblock submit %}</button>
                 {% endblock actions %}
             </footer>
         </div>

--- a/nadlogar/templates/problems/create_generator.html
+++ b/nadlogar/templates/problems/create_generator.html
@@ -1,11 +1,12 @@
 {% extends 'form.html' %}
+{% load crispy_forms_tags %}
 
 {% block title %}
 Izberi vrsto naloge
 {% endblock title %}
 
 {% block form_body %}
-{{ form.as_ul }}
+{{ form|crispy }}
 {% endblock form_body %}
 
 {% block submit %}

--- a/nadlogar/templates/problems/create_parameters.html
+++ b/nadlogar/templates/problems/create_parameters.html
@@ -1,11 +1,12 @@
 {% extends 'form.html' %}
+{% load crispy_forms_tags %}
 
 {% block title %}
 Izberi parametre
 {% endblock title %}
 
 {% block form_body %}
-{{ form.as_ul }}
+{{ form|crispy }}
 {% endblock form_body %}
 
 {% block submit %}

--- a/nadlogar/templates/problems/create_text.html
+++ b/nadlogar/templates/problems/create_text.html
@@ -1,4 +1,5 @@
 {% extends 'form.html' %}
+{% load crispy_forms_tags %}
 
 {% block method %}POST{% endblock method %}
 
@@ -7,13 +8,12 @@ Izberi besedilo
 {% endblock title %}
 
 {% block form_body %}
-{{ form.text.errors }}
-{{ form.text.label_tag }}
-{{ form.text }}
-{{ form.non_field_errors }}
-{% for field in form.hidden_fields %}
-{{ field }}
-{% endfor %}
+    {{ form.text.label_tag }}
+    {{ form.text }}
+    {{ form.non_field_errors }}
+    {% for field in form.hidden_fields %}
+        {{ field|as_crispy_field }}
+    {% endfor %}
 {% endblock form_body %}
 
 {% block submit %}


### PR DESCRIPTION
Obrazce formatiramo s pomočjo `django_crispy_forms` in bootstrapa. Polja se prikažejo čez celo podokno.

Closes #13.